### PR TITLE
feat(transactions): add backend CRUD (entity, DTOs, repo, service, controller)

### DIFF
--- a/backend/appvengers/src/main/java/com/backend/appvengers/controller/TransactionController.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/controller/TransactionController.java
@@ -1,0 +1,65 @@
+package com.backend.appvengers.controller;
+
+import com.backend.appvengers.dto.ApiResponse;
+import com.backend.appvengers.dto.TransactionRequest;
+import com.backend.appvengers.dto.TransactionResponse;
+import com.backend.appvengers.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/transactions")
+@RequiredArgsConstructor
+@CrossOrigin(origins = "http://localhost:4200")
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> list(Authentication auth) {
+        String email = auth.getName();
+        List<TransactionResponse> txs = transactionService.findAllForUser(email);
+        return ResponseEntity.ok(new ApiResponse(true, "Transactions fetched", txs));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse> create(@Valid @RequestBody TransactionRequest req,
+                                              BindingResult bindingResult,
+                                              Authentication auth) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Validation failed", Map.of("errors", bindingResult.getFieldErrors())));
+        }
+
+        String email = auth.getName();
+        TransactionResponse created = transactionService.create(email, req);
+        return ResponseEntity.status(201).body(new ApiResponse(true, "Transaction created", created));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse> update(@PathVariable Integer id,
+                                              @Valid @RequestBody TransactionRequest req,
+                                              BindingResult bindingResult,
+                                              Authentication auth) {
+        if (bindingResult.hasErrors()) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, "Validation failed", Map.of("errors", bindingResult.getFieldErrors())));
+        }
+
+        String email = auth.getName();
+        TransactionResponse updated = transactionService.update(email, id, req);
+        return ResponseEntity.ok(new ApiResponse(true, "Transaction updated", updated));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse> delete(@PathVariable Integer id, Authentication auth) {
+        String email = auth.getName();
+        transactionService.delete(email, id);
+        return ResponseEntity.ok(new ApiResponse(true, "Transaction deleted"));
+    }
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/dto/TransactionRequest.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/dto/TransactionRequest.java
@@ -1,0 +1,30 @@
+package com.backend.appvengers.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionRequest {
+
+    private Integer id;
+
+    @NotNull
+    private BigDecimal amount;
+
+    @NotBlank
+    private String type;
+
+    private String category;
+
+    private String description;
+
+    private LocalDateTime transactionDate;
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/dto/TransactionResponse.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/dto/TransactionResponse.java
@@ -1,0 +1,20 @@
+package com.backend.appvengers.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data 
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionResponse {
+    private Integer id;
+    private BigDecimal amount;
+    private String type;
+    private String category;
+    private String description;
+    private LocalDateTime transactionDate;
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/entity/Transaction.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/entity/Transaction.java
@@ -1,0 +1,52 @@
+package com.backend.appvengers.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tbl_transaction")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "transaction_id")
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @NotNull
+    @Column(nullable = false)
+    private BigDecimal amount;
+
+    @NotNull
+    @Column(nullable = false)
+    private String type; // e.g., "income" or "expense"
+
+    private String category;
+
+    private String description;
+
+    @Column(name = "transaction_date")
+    private LocalDateTime transactionDate;
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/repository/TransactionRepository.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/repository/TransactionRepository.java
@@ -1,0 +1,13 @@
+package com.backend.appvengers.repository;
+
+import com.backend.appvengers.entity.Transaction;
+import com.backend.appvengers.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, Integer> {
+    List<Transaction> findByUser(User user);
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/service/TransactionService.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/service/TransactionService.java
@@ -1,0 +1,96 @@
+package com.backend.appvengers.service;
+
+import com.backend.appvengers.dto.TransactionRequest;
+import com.backend.appvengers.dto.TransactionResponse;
+import com.backend.appvengers.entity.Transaction;
+import com.backend.appvengers.entity.User;
+import com.backend.appvengers.repository.TransactionRepository;
+import com.backend.appvengers.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
+
+    public List<TransactionResponse> findAllForUser(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        return transactionRepository.findByUser(user).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public TransactionResponse create(String email, TransactionRequest req) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Transaction t = new Transaction();
+        t.setUser(user);
+        t.setAmount(req.getAmount());
+        t.setType(req.getType());
+        t.setCategory(req.getCategory());
+        t.setDescription(req.getDescription());
+        t.setTransactionDate(req.getTransactionDate());
+
+        Transaction saved = transactionRepository.save(t);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public TransactionResponse update(String email, Integer id, TransactionRequest req) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Transaction t = transactionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Transaction not found"));
+
+        if (!t.getUser().getId().equals(user.getId())) {
+            throw new RuntimeException("Not authorized");
+        }
+
+        t.setAmount(req.getAmount());
+        t.setType(req.getType());
+        t.setCategory(req.getCategory());
+        t.setDescription(req.getDescription());
+        t.setTransactionDate(req.getTransactionDate());
+
+        Transaction saved = transactionRepository.save(t);
+        return toResponse(saved);
+    }
+
+    @Transactional
+    public void delete(String email, Integer id) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        Transaction t = transactionRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Transaction not found"));
+
+        if (!t.getUser().getId().equals(user.getId())) {
+            throw new RuntimeException("Not authorized");
+        }
+
+        transactionRepository.delete(t);
+    }
+
+    private TransactionResponse toResponse(Transaction t) {
+        return new TransactionResponse(
+                t.getId(),
+                t.getAmount(),
+                t.getType(),
+                t.getCategory(),
+                t.getDescription(),
+                t.getTransactionDate()
+        );
+    }
+}


### PR DESCRIPTION
I added Transaction entity with timestamps and user relation; TransactionRequest/Response DTOs; TransactionRepository with findByUser; TransactionService for business logic (list/create/update/delete) using authenticated user; TransactionController exposing REST endpoints at /api/transactions returning ApiResponse. Relies on JWT auth and existing User repository.