### PR TITLE
ci(playwright): disable automatic Playwright tests, enable manual dispatch

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,17 +1,6 @@
 name: Playwright E2E Tests
 on:
-  push:
-    branches: [ main, master ]
-    paths:
-      - 'frontend/ibudget/**'
-      - 'backend/appvengers/**'
-      - '.github/workflows/playwright.yml'
-  pull_request:
-    branches: [ main, master ]
-    paths:
-      - 'frontend/ibudget/**'
-      - 'backend/appvengers/**'
-      - '.github/workflows/playwright.yml'
+  workflow_dispatch:
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
## Summary
- Changed Playwright workflow triggers to only run on workflow_dispatch.
- Removed push and pull_request triggers to prevent automatic execution.
## Motivation
- To allow manual control over when E2E tests are run.
- Reduces CI usage and potential noise from automatic runs during development.
EOF