### PR TITLE
feat(pom.xml): add dependecy for automatic mvnw changes

### DIFF
--- a/backend/appvengers/pom.xml
+++ b/backend/appvengers/pom.xml
@@ -117,9 +117,16 @@
 
 	<!-- For sending emails -->
 	<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-			<version>3.5.7</version>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-mail</artifactId>
+		<version>3.5.7</version>
+	</dependency>
+
+	<!-- Automatic ./mvnw spring-boot:run -->
+	<dependency>
+  		<groupId>org.springframework.boot</groupId>
+  		<artifactId>spring-boot-devtools</artifactId>
+  		<optional>true</optional>
 	</dependency>
 </dependencies>
 


### PR DESCRIPTION
This commit introduces a new dependency to automatically read changes whenever "./mvnw spring-boot:run" is executed. TAKE NOTE that the frontend still needs to be refreshed in order for the backend changes to apply.