### PR TITLE
fix(SecurityConfig.java): Add production CORS origins for signup/login endpoints

### DIFF
--- a/backend/appvengers/src/main/java/com/backend/appvengers/config/SecurityConfig.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/config/SecurityConfig.java
@@ -46,7 +46,11 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:4200"));
+        configuration.setAllowedOrigins(Arrays.asList(
+            "http://localhost:4200",           // Development
+            "https://i-budget.site",           // Production
+            "https://www.i-budget.site"        // Production (www)
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## Summary
Fixes 403 Forbidden errors on production signup and login by adding production URLs to CORS allowed origins.
## Problem
- Production signup/login failing with 403 Forbidden
- CORS configuration only allowed http://localhost:4200
- POST requests from https://i-budget.site were blocked
## Solution
Updated SecurityConfig.java CORS configuration to include:
- https://i-budget.site (production)
- https://www.i-budget.site (production www)
- Maintains http://localhost:4200 (development)
## Impact
This fixes all authentication endpoints:
- ✅ /api/auth/signup - User registration
- ✅ /api/auth/login - User authentication
- ✅ /api/auth/verify-email - Email verification
- ✅ All other POST/PUT/DELETE auth endpoints
## Testing
Tested using Playwright browser automation:
1. Navigated to production site
2. Attempted signup with test credentials
3. Identified 403 error from CORS policy
4. Fixed CORS configuration
5. Requires deployment to verify fix
## Files Changed
- backend/appvengers/src/main/java/com/backend/appvengers/config/SecurityConfig.java
## Deployment Notes
- CD pipeline will auto-deploy on merge to main
- No database migrations required
- No breaking changes