### PR TITLE
fixspending-chart): update chart configuration and add chart.js registration

### DIFF
--- a/frontend/ibudget/src/app/dashboard/spending-chart/spending-chart.spec.ts
+++ b/frontend/ibudget/src/app/dashboard/spending-chart/spending-chart.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SpendingChart } from './spending-chart';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
 describe('SpendingChart', () => {
   let component: SpendingChart;
@@ -8,7 +9,10 @@ describe('SpendingChart', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [SpendingChart]
+      imports: [SpendingChart],
+      providers: [
+        provideCharts(withDefaultRegisterables())
+      ]
     })
     .compileComponents();
 

--- a/frontend/ibudget/src/app/dashboard/spending-chart/spending-chart.ts
+++ b/frontend/ibudget/src/app/dashboard/spending-chart/spending-chart.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { ChartData, ChartType } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
+import { ChartData, ChartType,} from 'chart.js';
 
 @Component({
   selector: 'app-spending-chart',
@@ -32,15 +32,6 @@ export class SpendingChart implements OnInit{
           data: [1200, 1500, 1000, 1700, 1300, 1600, 1800],
           backgroundColor: 'rgba(54, 162, 235, 0.4)',
         }]
-    }
-
-    const config = {
-      type: 'bar',
-      data: data,
-      options: {
-        responsive: true,
-        maintainAspectRatio: false,
-      },
     }
 
     this.spendingChartData = {


### PR DESCRIPTION
I fixed the 'bar is not registered' fail test spec. 

Kindly approve once the test pass, thank you.