### PR TITLE
feat(backend): implement soft delete and account deactivation APIs

### DIFF
--- a/backend/appvengers/src/main/java/com/backend/appvengers/controller/UserController.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.backend.appvengers.controller;
 
 import com.backend.appvengers.dto.ApiResponse;
+import com.backend.appvengers.dto.DeactivateAccountRequest;
+import com.backend.appvengers.dto.DeleteAccountRequest;
 import com.backend.appvengers.entity.User;
 import com.backend.appvengers.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -31,5 +35,51 @@ public class UserController {
         );
 
         return ResponseEntity.ok(new ApiResponse(true, "Profile fetched", data));
+    }
+
+    @PostMapping("/deactivate")
+    public ResponseEntity<ApiResponse> deactivateAccount(
+            Authentication auth,
+            @Valid @RequestBody DeactivateAccountRequest request,
+            BindingResult bindingResult) {
+        
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getFieldErrors().stream()
+                    .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("Validation failed");
+            return ResponseEntity.badRequest().body(new ApiResponse(false, errorMessage));
+        }
+
+        try {
+            String email = auth.getName();
+            ApiResponse response = userService.deactivateAccount(email, request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, e.getMessage()));
+        }
+    }
+
+    @PostMapping("/delete")
+    public ResponseEntity<ApiResponse> deleteAccount(
+            Authentication auth,
+            @Valid @RequestBody DeleteAccountRequest request,
+            BindingResult bindingResult) {
+        
+        if (bindingResult.hasErrors()) {
+            String errorMessage = bindingResult.getFieldErrors().stream()
+                    .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                    .reduce((a, b) -> a + ", " + b)
+                    .orElse("Validation failed");
+            return ResponseEntity.badRequest().body(new ApiResponse(false, errorMessage));
+        }
+
+        try {
+            String email = auth.getName();
+            ApiResponse response = userService.softDeleteAccount(email, request);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ApiResponse(false, e.getMessage()));
+        }
     }
 }

--- a/backend/appvengers/src/main/java/com/backend/appvengers/dto/DeactivateAccountRequest.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/dto/DeactivateAccountRequest.java
@@ -1,0 +1,19 @@
+package com.backend.appvengers.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeactivateAccountRequest {
+
+    @NotBlank(message = "Password is required to deactivate account")
+    private String password;
+
+    @Size(max = 500, message = "Reason must be at most 500 characters")
+    private String reason;
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/dto/DeleteAccountRequest.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/dto/DeleteAccountRequest.java
@@ -1,0 +1,19 @@
+package com.backend.appvengers.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteAccountRequest {
+
+    @NotBlank(message = "Password is required to delete account")
+    private String password;
+
+    @Size(max = 500, message = "Reason must be at most 500 characters")
+    private String reason;
+}

--- a/backend/appvengers/src/main/java/com/backend/appvengers/entity/User.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/entity/User.java
@@ -8,12 +8,16 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "tbl_user")
+@SQLDelete(sql = "UPDATE tbl_user SET is_deleted = true, deleted_at = NOW() WHERE user_id = ?")
+@SQLRestriction("is_deleted = false")
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
@@ -79,4 +83,20 @@ public class User {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // Soft delete fields
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Column(name = "deletion_reason")
+    private String deletionReason;
+
+    @Column(name = "deactivated_at")
+    private LocalDateTime deactivatedAt;
+
+    @Column(name = "deactivation_reason")
+    private String deactivationReason;
 }

--- a/backend/appvengers/src/main/java/com/backend/appvengers/repository/UserRepository.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.backend.appvengers.repository;
 
 import com.backend.appvengers.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -22,4 +24,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmailVerificationToken(String token);
 
     Optional<User> findByPasswordResetToken(String token);
+
+    // Query methods that bypass @SQLRestriction to include soft-deleted users
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailIncludingDeleted(@Param("email") String email);
+
+    @Query("SELECT u FROM User u WHERE u.username = :username")
+    Optional<User> findByUsernameIncludingDeleted(@Param("username") String username);
+
+    // Check if email exists including deleted accounts (for preventing re-registration)
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u WHERE u.email = :email")
+    boolean existsByEmailIncludingDeleted(@Param("email") String email);
+
+    // Check if username exists including deleted accounts
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u WHERE u.username = :username")
+    boolean existsByUsernameIncludingDeleted(@Param("username") String username);
 }


### PR DESCRIPTION
## Summary
- Implement soft delete and account deactivation APIs for user accounts, enabling temporary deactivation (reversible) and GDPR-compliant soft deletion with 30-day data recovery capability
- Add @SQLDelete and @SQLRestriction Hibernate annotations for automatic soft delete filtering across all queries
## New API Endpoints
| Endpoint | Method | Auth | Description |
|----------|--------|------|-------------|
| /api/user/deactivate | POST | JWT | Temporarily deactivate account (sets is_active = false) |
| /api/user/delete | POST | JWT | Soft delete account (sets is_deleted = true) |
## Request Body (both endpoints)
`json
{
  "password": "required - for verification",
  "reason": "optional - max 500 chars"
}
`
## Files Changed
- entity/User.java - Added soft delete fields and Hibernate annotations
- dto/DeactivateAccountRequest.java - New DTO
- dto/DeleteAccountRequest.java - New DTO
- 
epository/UserRepository.java - Added soft-delete aware query methods
- service/UserService.java - Added deactivate/delete business logic
- controller/UserController.java - Added new endpoints
## Database Migration (Already Applied to VPS)
`sql
ALTER TABLE tbl_user 
    ADD COLUMN deleted_at DATETIME NULL,
    ADD COLUMN deletion_reason VARCHAR(500) NULL,
    ADD COLUMN deactivated_at DATETIME NULL,
    ADD COLUMN deactivation_reason VARCHAR(500) NULL;
CREATE INDEX idx_user_is_deleted ON tbl_user(is_deleted);
`
## Testing
- Build: Passed
- Unit tests: Passed