### PR TITLE
fix(notifications): restore white background color

### DIFF
--- a/frontend/ibudget/src/app/notifications/notifications.scss
+++ b/frontend/ibudget/src/app/notifications/notifications.scss
@@ -1,4 +1,4 @@
-$background-color: #E8E9EB;
+$background-color: #ffffff;
 $sidebar-width: 80px;
 
 .notifications-container {


### PR DESCRIPTION
## Summary
- Restores the notifications page background to white (`#ffffff`)
- Reverts unintended gray background (`#E8E9EB`) that was accidentally re-introduced

## What Happened
The white background was changed to gray in commit `0e72eee` during a sidebar refactor. This fix restores the clean, uniform white appearance.

## Changes
```scss
// Before (gray)
$background-color: #E8E9EB;

// After (white)
$background-color: #ffffff;
```

## Visual Impact
- Clean, uniform white background on notifications page
- Eliminates two-tone effect between page background and notification cards