### PR TITLE
fix(notifications): use urgency-based colors for savings deadline notifications

### DIFF
--- a/backend/appvengers/src/main/java/com/backend/appvengers/dto/NotificationResponse.java
+++ b/backend/appvengers/src/main/java/com/backend/appvengers/dto/NotificationResponse.java
@@ -16,6 +16,7 @@ public class NotificationResponse {
     private String date;
     private Double amount;
     private String type; // NotificationType enum value (e.g., 'SAVINGS_MILESTONE_50', 'BUDGET_WARNING')
+    private String urgency; // Urgency level: LOW, MEDIUM, HIGH (for deadline-based coloring)
     private boolean read;
     private String category;
     private String savingName; // Optional for savings notifications
@@ -48,6 +49,11 @@ public class NotificationResponse {
             response.setType(notification.getType().name());
         } else {
             response.setType("info"); // Fallback
+        }
+
+        // Set urgency level for deadline-based coloring (HIGH=red, MEDIUM=orange, LOW=blue)
+        if (notification.getUrgency() != null) {
+            response.setUrgency(notification.getUrgency().name());
         }
 
         return response;

--- a/frontend/ibudget/src/app/notifications/notifications.html
+++ b/frontend/ibudget/src/app/notifications/notifications.html
@@ -18,7 +18,7 @@
         <div
           class="notification-item"
           [class.unread]="!notification.read"
-          [ngClass]="notificationService.getNotificationColor(notification.type)">
+          [ngClass]="notificationService.getNotificationColor(notification.type, notification.urgency)">
           
           <div class="notification-icon">
             <i [ngClass]="notificationService.getNotificationIcon(notification.type)"></i>

--- a/frontend/ibudget/src/models/user.model.ts
+++ b/frontend/ibudget/src/models/user.model.ts
@@ -77,6 +77,7 @@ export type Notification = {
   date: string;
   amount?: number;
   type: 'warning' | 'info' | 'alert' | 'BUDGET_WARNING' | 'BUDGET_EXCEEDED' | 'SAVINGS_DEADLINE' | 'SAVINGS_COMPLETED' | 'SAVINGS_MILESTONE_50' | 'SAVINGS_MILESTONE_75';
+  urgency?: 'LOW' | 'MEDIUM' | 'HIGH'; // Urgency level for deadline-based coloring
   read: boolean;
   category?: string;
   savingName?: string;

--- a/frontend/ibudget/src/services/notification.ts
+++ b/frontend/ibudget/src/services/notification.ts
@@ -236,7 +236,19 @@ export class NotificationService implements OnDestroy {
     return this.iconMap.get(type) || 'fas fa-bell';
   }
 
-  getNotificationColor(type: string): string {
+  getNotificationColor(type: string, urgency?: string): string {
+    // For SAVINGS_DEADLINE, use urgency-based coloring
+    if (type === 'SAVINGS_DEADLINE' && urgency) {
+      switch (urgency) {
+        case 'HIGH':
+          return 'alert';    // Red for today/tomorrow
+        case 'MEDIUM':
+          return 'warning';  // Orange for 3 days
+        case 'LOW':
+        default:
+          return 'info';     // Blue for 7 days
+      }
+    }
     return this.colorMap.get(type) || 'info';
   }
 


### PR DESCRIPTION
## Summary
- Fix savings deadline notifications showing wrong colors based on urgency level
- Notifications due TODAY/tomorrow now show **red** (HIGH urgency) instead of blue
- Notifications due in 3 days show **orange** (MEDIUM urgency)
- Notifications due in 7 days show **blue** (LOW urgency)

## Changes
- **Backend**: Add `urgency` field to `NotificationResponse` DTO
- **Frontend**: Add `urgency` field to `Notification` type model
- **Frontend**: Update `getNotificationColor()` to use urgency-based coloring for `SAVINGS_DEADLINE` type
- **Frontend**: Pass `urgency` parameter in notifications template