### PR TITLE
Fix savings page height to 100%

### DIFF
--- a/frontend/ibudget/src/app/savings/savings.scss
+++ b/frontend/ibudget/src/app/savings/savings.scss
@@ -5,7 +5,7 @@ $border-color: #ccc;
 $box-shadow-definition: 2px 2px 8px rgba(0, 0, 0, 0.1);
 
 main {
-  @include m.page-layout(10px, auto);
+  @include m.page-layout(10px, 100%);
 }
 
 .inner-wrapper  {


### PR DESCRIPTION
Update the savings page layout to set the height to 100% instead of auto.