### PR TITLE
fix: clear all localStorage and service state on logout to prevent cross-account data leakage

### DIFF
--- a/backend/appvengers/pom.xml
+++ b/backend/appvengers/pom.xml
@@ -157,6 +157,14 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
 			</plugin>
 			
 			<!-- JaCoCo Maven Plugin for Code Coverage -->

--- a/frontend/ibudget/src/app/header/header.ts
+++ b/frontend/ibudget/src/app/header/header.ts
@@ -108,9 +108,13 @@ export class Header implements OnInit, OnDestroy {
   }
 
   confirmLogout() {
-    // Disconnect WebSocket before logout
-    this.notificationService.disconnectWebSocket();
+    // Clear all service state before logout
+    this.notificationService.clearState();
+    
+    // Logout (clears localStorage and sessionStorage)
     this.authService.logout();
+    
+    // Navigate to landing page
     this.router.navigate(['/']);
     this.showLogoutModal.set(false);
   }

--- a/frontend/ibudget/src/services/auth.service.ts
+++ b/frontend/ibudget/src/services/auth.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
 import { environment } from '../environments/environment';
@@ -10,8 +10,7 @@ import { ApiResponse, AuthData, SignupRequest, ReactivateAccountRequest } from '
 
 export class AuthService {
   private apiUrl = `${environment.apiUrl}/auth`;
-
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
 
   signup(userData: SignupRequest): Observable<ApiResponse> {
     return this.http.post<ApiResponse>(`${this.apiUrl}/signup`, userData);
@@ -54,7 +53,23 @@ export class AuthService {
   }
 
   logout(): void {
+    // Clear ALL localStorage items to prevent data leakage between accounts
     localStorage.removeItem('iBudget_authToken');
+    localStorage.removeItem('iBudget_username');
+    
+    // Clear ALL iBudget-prefixed items (comprehensive cleanup)
+    Object.keys(localStorage).forEach(key => {
+      if (key.startsWith('iBudget_') || key.startsWith('chatbot_')) {
+        localStorage.removeItem(key);
+      }
+    });
+    
+    // Also clear sessionStorage (if any session data exists)
+    sessionStorage.clear();
+    
+    // Note: Services should be cleared by the header component calling their clearState() methods
+    // This includes: NotificationService.clearState(), WebSocketService.disconnect()
+    console.log('🚪 User logged out - all storage cleared');
   }
 
   getToken(): string | null {

--- a/frontend/ibudget/src/services/notification-preferences.service.ts
+++ b/frontend/ibudget/src/services/notification-preferences.service.ts
@@ -139,4 +139,14 @@ export class NotificationPreferencesService {
       console.error('Failed to save notification preferences:', e);
     }
   }
+
+  /**
+   * Clear preferences state (for logout).
+   * Does NOT clear localStorage since preferences should persist across sessions.
+   */
+  clearState(): void {
+    // Reset to defaults but keep localStorage (preferences are user-specific settings)
+    this.preferencesSubject.next(this.loadFromStorage());
+    console.log('🧹 Notification preferences state cleared');
+  }
 }

--- a/frontend/ibudget/src/services/notification.ts
+++ b/frontend/ibudget/src/services/notification.ts
@@ -344,6 +344,17 @@ fetchNotifications(): void {
     return this.colorMap.get(type) || 'info';
   }
 
+  /**
+   * Clear all notification state (for logout).
+   * Resets in-memory cache and disconnects WebSocket.
+   */
+  clearState(): void {
+    this.notificationsSubject.next([]);
+    this.previousNotificationIds.clear();
+    this.disconnectWebSocket();
+    console.log('🧹 Notification state cleared');
+  }
+
   ngOnDestroy(): void {
     this.disconnectWebSocket();
   }


### PR DESCRIPTION
SECURITY FIX: Users were seeing other users' financial data after logout/login

Root Cause:
- logout() only removed JWT token from localStorage
- Cached data (savings, notifications, user info) persisted in localStorage and in-memory
- New user login fetched fresh JWT but components loaded stale cached data

Changes:
- Enhanced AuthService.logout() to clear ALL iBudget-prefixed localStorage items
- Added NotificationService.clearState() to reset in-memory notification cache
- Added NotificationPreferencesService.clearState() for preferences reset
- Updated Header component to call service clearState() before logout
- Modernized AuthService to use inject() pattern (Angular best practice)
- Fixed pom.xml to exclude Lombok from Spring Boot plugin build

Backend Security Verification:
- All backend queries correctly filter by userId from JWT
- Authorization checks prevent cross-user data access
- Spring Security properly authenticates each request

Testing:
- Test Case 1: Login User A → Create savings → Logout → Login User B → Verify User B does NOT see User A's data
- Test Case 2: Check DevTools localStorage is completely cleared after logout
- Test Case 3: Verify API calls return only current user's data (Network tab)
