### PR TITLE
fix(pwa): restore navigationUrls exclusions removed in security fix

### DIFF
--- a/frontend/ibudget/ngsw-config.json
+++ b/frontend/ibudget/ngsw-config.json
@@ -80,5 +80,13 @@
         "timeout": "5s"
       }
     }
+  ],
+  "navigationUrls": [
+    "/**",
+    "!/api/**",
+    "!/ws-notifications/**",
+    "!/oauth2/**",
+    "!/login/oauth2/**",
+    "!/auth/callback/**"
   ]
 }


### PR DESCRIPTION
The security fix commit (d8550ed9) accidentally removed the navigationUrls
section when cleaning up API cache groups. This caused Service Worker to
intercept ALL navigation requests, including /oauth2/authorization/google,
resulting in OAuth2 returning 404 Not Found.

Without navigationUrls exclusions, the Service Worker serves index.html
(Angular app) for backend OAuth2 endpoints instead of forwarding them.

This restores the navigationUrls section with all necessary exclusions:
- !/api/** - Backend API calls
- !/ws-notifications/** - WebSocket connections
- !/oauth2/** - OAuth2 authorization initiation
- !/login/oauth2/** - OAuth2 callback from Google
- !/auth/callback/** - Frontend OAuth2 callback handler

Fixes: OAuth2 authentication flow broken after security fix
