### PR TITLE
fix(chatbot): resolve voice selection bug and implement user-scoped voice preferences

### DIFF
--- a/frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.html
+++ b/frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.html
@@ -31,7 +31,7 @@
         </div>
         <div class="settings-content">
             <label class="settings-label">Select Voice</label>
-            <select class="voice-select" [ngModel]="currentVoiceName()" (ngModel Change)="selectVoice($event)">
+            <select class="voice-select" [ngModel]="currentVoiceName()" (ngModelChange)="selectVoice($event)">
                 @for (group of getGroupedVoices(); track group.lang) {
                 <optgroup [label]="group.langName">
                     @for (voice of group.voices; track voice.name) {

--- a/frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.ts
+++ b/frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.ts
@@ -189,6 +189,9 @@ export class ChatbotSidebar implements OnInit, OnDestroy {
             return;
         }
 
+        // Reload voices to load this user's saved voice preference
+        this.speechService.reloadVoices();
+
         if (!environment.production) {
             console.log('[ChatbotSidebar] Loading messages for user', userId);
         }


### PR DESCRIPTION
## Summary
Fixes the chatbot voice selection bug where users couldn't change their preferred voice, and implements proper user-scoped voice preferences.

## Changes Made

### Bug Fixes
- **Fixed event binding typo** in `chatbot-sidebar.html`: `(ngModel Change)` → `(ngModelChange)` - this was preventing the voice selection dropdown from working at all

### User-Scoped Voice Preferences
- **Updated `SpeechService`** to use user-scoped `LocalStorageService` for voice preferences
- Added fallback to direct `localStorage` for pre-login scenarios
- Added `reloadVoices()` method to reload user's saved preference when they log in

### Integration
- **Updated `ChatbotSidebar`** to call `reloadVoices()` when user changes accounts
- Voice preferences now properly isolate between different users on the same browser

## Files Changed
- `frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.html` - Fixed event binding
- `frontend/ibudget/src/app/chatbot-sidebar/chatbot-sidebar.ts` - Added reload on user change
- `frontend/ibudget/src/services/speech.service.ts` - User-scoped storage with fallback

## Testing
1. Voice selection now works when clicking dropdown options
2. Voice preferences persist across page refreshes
3. Different users on same browser have isolated voice preferences
4. No console errors before login

## Breaking Changes
None
