### PR TITLE
fix(chatbot): improve TTS pronunciation of Philippine Peso symbol

### DIFF
--- a/frontend/ibudget/src/services/speech.service.ts
+++ b/frontend/ibudget/src/services/speech.service.ts
@@ -523,6 +523,10 @@ export class SpeechService implements OnDestroy {
    */
   private cleanTextForSpeech(text: string): string {
     return text
+      // Replace Philippine Peso symbol with number-first format
+      .replace(/₱(\d+(?:,\d{3})*(?:\.\d{2})?)/g, '$1 Philippine Pesos')
+      // Fallback for ₱ without numbers (replace with currency name)
+      .replace(/₱/g, 'Philippine Pesos')
       // Remove emojis (comprehensive Unicode ranges)
       // Emoticons: 😀-🙏 (U+1F600-U+1F64F)
       // Symbols & Pictographs: 🌀-🗿 (U+1F300-U+1F5FF)


### PR DESCRIPTION
## Summary
Fixes the Text-to-Speech pronunciation of the Philippine Peso (₱) symbol to correctly say "Philippine Pesos" instead of "Cuban Pesos".

## Problem
The Web Speech API was interpreting the ₱ symbol as "Cuban Pesos" because it associates the ₱ currency code with Cuba rather than the Philippines.

## Solution
Enhanced the `cleanTextForSpeech()` method to intelligently replace ₱ symbols with proper pronunciation.

## Changes Made
- **Smart ₱ Symbol Replacement**: Uses regex to detect ₱ followed by numbers and reorders to natural speech format:
  - ₱5,000 → "5,000 Philippine Pesos"
  - ₱2,500.75 → "2,500.75 Philippine Pesos"
  - ₱123,456,789.99 → "123,456,789.99 Philippine Pesos"
- **Fallback Handling**: ₱ without numbers becomes "Philippine Pesos"
- **Regex Pattern**: Handles complex number formats with commas and decimals

## Files Changed
- `frontend/ibudget/src/services/speech.service.ts`

## Testing
**Before:** "Your budget is ₱5,000" → "Your budget is Cuban Pesos 5,000"  
**After:** "Your budget is ₱5,000" → "Your budget is 5,000 Philippine Pesos"

## Breaking Changes
None