### PR TITLE
fix: remove the day in the monthly transactions filter.

### DIFF
--- a/frontend/ibudget/src/app/transactions/transactions.html
+++ b/frontend/ibudget/src/app/transactions/transactions.html
@@ -201,7 +201,11 @@
               } @else if (getRelativeDate(transaction.date) === 'Yesterday') {
                 Yesterday
               } @else {
-                {{ transaction.date | date:'EEEE, MMM d, y' }}
+                @if (selectedPeriod === 'monthly') {
+                  {{ transaction.date | date:'MMMM y' }}
+                } @else {
+                  {{ transaction.date | date:'EEEE, MMM d, y' }}
+                }
               }
             </div>
           }

--- a/frontend/ibudget/src/app/transactions/transactions.ts
+++ b/frontend/ibudget/src/app/transactions/transactions.ts
@@ -924,6 +924,12 @@ ngOnInit() {
     yesterday.setDate(yesterday.getDate() - 1);
     yesterday.setHours(0, 0, 0, 0);
     
+    // For monthly view, group by month/year instead of day
+    if (this.selectedPeriod === 'monthly') {
+      const monthYear = `${transactionDate.getFullYear()}-${transactionDate.getMonth()}`;
+      return monthYear;
+    }
+    
     if (transactionDate.getTime() === today.getTime()) {
       return 'Today';
     } else if (transactionDate.getTime() === yesterday.getTime()) {


### PR DESCRIPTION
### Changes

- Removed the day in the monthly filter option to avoid user confusion

# Prod
<img width="916" height="448" alt="image" src="https://github.com/user-attachments/assets/3ddb0210-7752-49f4-ae0d-27b8f70123f3" />

The date for monthly shows the most latest date (December 25, 2025) but the user also has a transactions in December 9, 2025 (13th Month Pay). The date is possible to confuse the user since it only displays December 25.

# Local (Upcoming Change)
<img width="915" height="451" alt="image" src="https://github.com/user-attachments/assets/bac74f0a-ed2d-4836-948e-e7301502bc46" />

The date only displays the month and year. This is a better display of dates to avoid confusion with transactions.